### PR TITLE
Fix duplicate record error message

### DIFF
--- a/lib/entity-base.js
+++ b/lib/entity-base.js
@@ -61,10 +61,10 @@ Entity.prototype._normalizeError = function(err) {
   var error = new appError.Validation(err);
   switch(err.code) {
   case 11000:
-    var items = err.errmsg.match(/key error index:\s(.+)\.(\w+)\.\$([\w\_]+)\s/);
+    // var items = err.errmsg.match(/key error index:\s(.+)\.(\w+)\.\$([\w\_]+)\s/);
     // error.db = items[1];
     // error.collection = items[2];
-    error.index = items[3];
+    // error.index = items[3];
     error.message = 'Duplicate record found';
 
     // now cleanup the error object


### PR DESCRIPTION
Line 64 does not match all 3, so code breaks on line 67 `error.index = items[3];` and message does not get set.